### PR TITLE
Settings: Add preference for maximum screen refresh rate

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -4972,5 +4972,7 @@
     <!-- Refresh rate -->
     <string name="min_refresh_rate_title">Taxa mínima de atualização</string>
     <string name="max_refresh_rate_title">Taxa máxima de atualização</string>
+    <string name="battery_saver_refresh_rate_title">Reduza a taxa de atualização</string>
+    <string name="battery_saver_refresh_rate_summary">Use 60 Hz como taxa de atualização máxima para economizar energia quando a Economia de bateria estiver ativada</string>
     
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -4968,4 +4968,9 @@
     <string name="bluetooth_phonebook_access_notification_content" msgid="4280361621526852063">"Um dispositivo não confiável quer acessar seus contatos e seu registro de chamadas. Toque para ver detalhes."</string>
     <string name="bluetooth_phonebook_access_dialog_title" msgid="7624607995928968721">"Conceder acesso aos contatos e ao registro de chamadas?"</string>
     <string name="bluetooth_phonebook_access_dialog_content" msgid="4766700015848574532">"Um dispositivo Bluetooth não confiável, <xliff:g id="DEVICE_NAME_0">%1$s</xliff:g>, quer acessar seus contatos e seu registro de chamadas. Isso inclui dados sobre chamadas recebidas e realizadas.\n\nVocê não se conectou a <xliff:g id="DEVICE_NAME_1">%2$s</xliff:g> antes."</string>
+    
+    <!-- Refresh rate -->
+    <string name="min_refresh_rate_title">Taxa mínima de atualização</string>
+    <string name="max_refresh_rate_title">Taxa máxima de atualização</string>
+    
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -4972,7 +4972,5 @@
     <!-- Refresh rate -->
     <string name="min_refresh_rate_title">Taxa mínima de atualização</string>
     <string name="max_refresh_rate_title">Taxa máxima de atualização</string>
-    <string name="battery_saver_refresh_rate_title">Reduza a taxa de atualização</string>
-    <string name="battery_saver_refresh_rate_summary">Use 60 Hz como taxa de atualização máxima para economizar energia quando a Economia de bateria estiver ativada</string>
     
 </resources>

--- a/res/values/syberia_config.xml
+++ b/res/values/syberia_config.xml
@@ -22,8 +22,8 @@
     <!-- Smart Charging -->
     <bool name="config_supportSmartCharging">false</bool>
 
-    <!-- Whether to show min refresh rate in display settings -->
-    <bool name="config_show_min_refresh_rate_switch">false</bool>
+    <!-- Whether to show min/max refresh rate in display settings -->
+    <bool name="config_show_refresh_rate_controls">false</bool>
 
     <!-- Battery Health -->
     <string name="config_batCurCap"></string>

--- a/res/values/syberia_strings.xml
+++ b/res/values/syberia_strings.xml
@@ -271,6 +271,8 @@
     <!-- Refresh rate -->
     <string name="min_refresh_rate_title">Minimum refresh rate</string>
     <string name="max_refresh_rate_title">Maximum refresh rate</string>
+    <string name="battery_saver_refresh_rate_title">Reduce refresh rate</string>
+    <string name="battery_saver_refresh_rate_summary">Use 60 Hz as max refresh rate to save power when Battery Saver is on</string>
 
     <!-- Mobile network setting screen, summary of Mobile data switch preference when the network
          is unavailable, the preference selection will be disabled. [CHAR LIMIT=NONE] -->

--- a/res/values/syberia_strings.xml
+++ b/res/values/syberia_strings.xml
@@ -268,8 +268,9 @@
     <string name="smart_charging_reset_stats_summary">Reset battery statistics after reaching user defined charging level</string>
     <string name="smart_charging_footer">Smart Charging allows you to set maximum charging level to extend the lifespan of your battery</string>
 
-    <!-- Min refresh rate -->
+    <!-- Refresh rate -->
     <string name="min_refresh_rate_title">Minimum refresh rate</string>
+    <string name="max_refresh_rate_title">Maximum refresh rate</string>
 
     <!-- Mobile network setting screen, summary of Mobile data switch preference when the network
          is unavailable, the preference selection will be disabled. [CHAR LIMIT=NONE] -->

--- a/res/values/syberia_strings.xml
+++ b/res/values/syberia_strings.xml
@@ -271,8 +271,6 @@
     <!-- Refresh rate -->
     <string name="min_refresh_rate_title">Minimum refresh rate</string>
     <string name="max_refresh_rate_title">Maximum refresh rate</string>
-    <string name="battery_saver_refresh_rate_title">Reduce refresh rate</string>
-    <string name="battery_saver_refresh_rate_summary">Use 60 Hz as max refresh rate to save power when Battery Saver is on</string>
 
     <!-- Mobile network setting screen, summary of Mobile data switch preference when the network
          is unavailable, the preference selection will be disabled. [CHAR LIMIT=NONE] -->

--- a/res/xml/battery_saver_settings.xml
+++ b/res/xml/battery_saver_settings.xml
@@ -33,6 +33,12 @@
         settings:keywords="@string/keywords_battery_saver_sticky"
         settings:controller="com.android.settings.fuelgauge.batterysaver.BatterySaverStickyPreferenceController"/>
 
+    <SwitchPreference
+        android:key="battery_saver_rr_switch"
+        android:title="@string/battery_saver_refresh_rate_title"
+        android:summary="@string/battery_saver_refresh_rate_summary"
+        settings:controller="com.android.settings.fuelgauge.batterysaver.BatterySaverRefreshRatePreferenceController" />
+
     <com.android.settings.widget.TwoStateButtonPreference
         android:key="battery_saver"
         android:title="@string/battery_saver"

--- a/res/xml/battery_saver_settings.xml
+++ b/res/xml/battery_saver_settings.xml
@@ -33,12 +33,6 @@
         settings:keywords="@string/keywords_battery_saver_sticky"
         settings:controller="com.android.settings.fuelgauge.batterysaver.BatterySaverStickyPreferenceController"/>
 
-    <SwitchPreference
-        android:key="battery_saver_rr_switch"
-        android:title="@string/battery_saver_refresh_rate_title"
-        android:summary="@string/battery_saver_refresh_rate_summary"
-        settings:controller="com.android.settings.fuelgauge.batterysaver.BatterySaverRefreshRatePreferenceController" />
-
     <com.android.settings.widget.TwoStateButtonPreference
         android:key="battery_saver"
         android:title="@string/battery_saver"

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -100,10 +100,10 @@
         android:summary="@string/summary_placeholder"
         settings:controller="com.android.settings.display.MinRefreshRatePreferenceController" />
 
-    <SwitchPreference
+    <ListPreference
         android:key="peak_refresh_rate"
-        android:title="@string/peak_refresh_rate_title"
-        android:summary="@string/peak_refresh_rate_summary"
+        android:title="@string/max_refresh_rate_title"
+        android:summary="@string/summary_placeholder"
         settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController" />
 
     <Preference

--- a/src/com/android/settings/display/MinRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/MinRefreshRatePreferenceController.java
@@ -40,15 +40,29 @@ public class MinRefreshRatePreferenceController extends BasePreferenceController
 
     private ListPreference mListPreference;
 
+    private List<String> mEntries = new ArrayList<>();
+    private List<String> mValues = new ArrayList<>();
+
     public MinRefreshRatePreferenceController(Context context) {
         super(context, KEY_MIN_REFRESH_RATE);
+
+        if (mContext.getResources().getBoolean(R.bool.config_show_refresh_rate_controls)) {
+            Display.Mode mode = mContext.getDisplay().getMode();
+            Display.Mode[] modes = mContext.getDisplay().getSupportedModes();
+            for (Display.Mode m : modes) {
+                if (m.getPhysicalWidth() == mode.getPhysicalWidth() &&
+                        m.getPhysicalHeight() == mode.getPhysicalHeight()) {
+                    mEntries.add(String.format("%.02fHz", m.getRefreshRate())
+                            .replaceAll("[\\.,]00", ""));
+                    mValues.add(String.format(Locale.US, "%.02f", m.getRefreshRate()));
+                }
+            }
+        }
     }
 
     @Override
     public int getAvailabilityStatus() {
-        return mContext.getResources().getBoolean(R.bool.config_show_min_refresh_rate_switch) &&
-                mListPreference != null && mListPreference.getEntries().length > 1
-                        ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+        return mEntries.size() > 1 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override
@@ -59,28 +73,18 @@ public class MinRefreshRatePreferenceController extends BasePreferenceController
     @Override
     public void displayPreference(PreferenceScreen screen) {
         mListPreference = screen.findPreference(getPreferenceKey());
-
-        List<String> entries = new ArrayList<>(), values = new ArrayList<>();
-        Display.Mode mode = mContext.getDisplay().getMode();
-        Display.Mode[] modes = mContext.getDisplay().getSupportedModes();
-        for (Display.Mode m : modes) {
-            if (m.getPhysicalWidth() == mode.getPhysicalWidth() &&
-                    m.getPhysicalHeight() == mode.getPhysicalHeight()) {
-                entries.add(String.format("%.02fHz", m.getRefreshRate())
-                        .replaceAll("[\\.,]00", ""));
-                values.add(String.format(Locale.US, "%.02f", m.getRefreshRate()));
-            }
-        }
-        mListPreference.setEntries(entries.toArray(new String[entries.size()]));
-        mListPreference.setEntryValues(values.toArray(new String[values.size()]));
+        mListPreference.setEntries(mEntries.toArray(new String[mEntries.size()]));
+        mListPreference.setEntryValues(mValues.toArray(new String[mValues.size()]));
 
         super.displayPreference(screen);
     }
 
     @Override
     public void updateState(Preference preference) {
+        final float defaultRefreshRate = (float) mContext.getResources().getInteger(
+                        com.android.internal.R.integer.config_defaultRefreshRate);
         final float currentValue = Settings.System.getFloat(mContext.getContentResolver(),
-                MIN_REFRESH_RATE, 60.00f);
+                MIN_REFRESH_RATE, defaultRefreshRate);
         int index = mListPreference.findIndexOfValue(
                 String.format(Locale.US, "%.02f", currentValue));
         if (index < 0) index = 0;
@@ -97,3 +101,4 @@ public class MinRefreshRatePreferenceController extends BasePreferenceController
     }
 
 }
+

--- a/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/PeakRefreshRatePreferenceController.java
@@ -17,178 +17,88 @@
 package com.android.settings.display;
 
 import android.content.Context;
-import android.hardware.display.DisplayManager;
-import android.os.Handler;
-import android.provider.DeviceConfig;
 import android.provider.Settings;
-import android.util.Log;
 import android.view.Display;
+import static android.provider.Settings.System.PEAK_REFRESH_RATE;
 
-import androidx.annotation.VisibleForTesting;
+import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceScreen;
 
 import com.android.settings.R;
-import com.android.settings.core.TogglePreferenceController;
-import com.android.settingslib.core.lifecycle.LifecycleObserver;
-import com.android.settingslib.core.lifecycle.events.OnStart;
-import com.android.settingslib.core.lifecycle.events.OnStop;
+import com.android.settings.core.BasePreferenceController;
 
-import java.util.concurrent.Executor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 
-public class PeakRefreshRatePreferenceController extends TogglePreferenceController
-        implements LifecycleObserver, OnStart, OnStop {
+public class PeakRefreshRatePreferenceController extends BasePreferenceController implements
+        Preference.OnPreferenceChangeListener {
 
-    @VisibleForTesting static float DEFAULT_REFRESH_RATE = 60f;
+    private static final String KEY_PEAK_REFRESH_RATE = "peak_refresh_rate";
 
-    @VisibleForTesting float mPeakRefreshRate;
+    private ListPreference mListPreference;
 
-    private static final String TAG = "RefreshRatePrefCtr";
-    private static final float INVALIDATE_REFRESH_RATE = -1f;
+    private List<String> mEntries = new ArrayList<>();
+    private List<String> mValues = new ArrayList<>();
 
-    private final Handler mHandler;
-    private final IDeviceConfigChange mOnDeviceConfigChange;
-    private final DeviceConfigDisplaySettings mDeviceConfigDisplaySettings;
-    private Preference mPreference;
+    public PeakRefreshRatePreferenceController(Context context) {
+        super(context, KEY_PEAK_REFRESH_RATE);
 
-    private interface IDeviceConfigChange {
-        void onDefaultRefreshRateChanged();
-    }
-
-    public PeakRefreshRatePreferenceController(Context context, String key) {
-        super(context, key);
-        mHandler = new Handler(context.getMainLooper());
-        mDeviceConfigDisplaySettings = new DeviceConfigDisplaySettings();
-        mOnDeviceConfigChange =
-                new IDeviceConfigChange() {
-                    public void onDefaultRefreshRateChanged() {
-                        updateState(mPreference);
-                    }
-                };
-
-        final DisplayManager dm = mContext.getSystemService(DisplayManager.class);
-        final Display display = dm.getDisplay(Display.DEFAULT_DISPLAY);
-
-        if (display == null) {
-            Log.w(TAG, "No valid default display device");
-            mPeakRefreshRate = DEFAULT_REFRESH_RATE;
-        } else {
-            mPeakRefreshRate = findPeakRefreshRate(display.getSupportedModes());
+        if (mContext.getResources().getBoolean(R.bool.config_show_refresh_rate_controls)) {
+            Display.Mode mode = mContext.getDisplay().getMode();
+            Display.Mode[] modes = mContext.getDisplay().getSupportedModes();
+            for (Display.Mode m : modes) {
+                if (m.getPhysicalWidth() == mode.getPhysicalWidth() &&
+                        m.getPhysicalHeight() == mode.getPhysicalHeight()) {
+                    mEntries.add(String.format("%.02fHz", m.getRefreshRate())
+                            .replaceAll("[\\.,]00", ""));
+                    mValues.add(String.format(Locale.US, "%.02f", m.getRefreshRate()));
+                }
+            }
         }
-
-        Log.d(
-                TAG,
-                "DEFAULT_REFRESH_RATE : "
-                        + DEFAULT_REFRESH_RATE
-                        + " mPeakRefreshRate : "
-                        + mPeakRefreshRate);
-    }
-
-    @Override
-    public void displayPreference(PreferenceScreen screen) {
-        super.displayPreference(screen);
-
-        mPreference = screen.findPreference(getPreferenceKey());
     }
 
     @Override
     public int getAvailabilityStatus() {
-        if (mContext.getResources().getBoolean(R.bool.config_show_smooth_display)) {
-            return mPeakRefreshRate > DEFAULT_REFRESH_RATE ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
-        } else {
-            return UNSUPPORTED_ON_DEVICE;
-        }
+        return mEntries.size() > 1 ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
     }
 
     @Override
-    public boolean isChecked() {
-        final float peakRefreshRate =
-                Settings.System.getFloat(
-                        mContext.getContentResolver(),
-                        Settings.System.PEAK_REFRESH_RATE,
-                        getDefaultPeakRefreshRate());
-        return peakRefreshRate == mPeakRefreshRate;
+
+    public String getPreferenceKey() {
+        return KEY_PEAK_REFRESH_RATE;
     }
 
     @Override
-    public boolean setChecked(boolean isChecked) {
-        final float peakRefreshRate = isChecked ? mPeakRefreshRate : DEFAULT_REFRESH_RATE;
-        Log.d(TAG, "setChecked to : " + peakRefreshRate);
+    public void displayPreference(PreferenceScreen screen) {
+        mListPreference = screen.findPreference(getPreferenceKey());
 
-        return Settings.System.putFloat(
-                mContext.getContentResolver(), Settings.System.PEAK_REFRESH_RATE, peakRefreshRate);
+        mListPreference.setEntries(mEntries.toArray(new String[mEntries.size()]));
+        mListPreference.setEntryValues(mValues.toArray(new String[mValues.size()]));
+
+        super.displayPreference(screen);
     }
 
     @Override
-    public void onStart() {
-        mDeviceConfigDisplaySettings.startListening();
+    public void updateState(Preference preference) {
+        final float defaultRefreshRate = (float) mContext.getResources().getInteger(
+                        com.android.internal.R.integer.config_defaultPeakRefreshRate);
+        final float currentValue = Settings.System.getFloat(mContext.getContentResolver(),
+                PEAK_REFRESH_RATE, defaultRefreshRate);
+        int index = mListPreference.findIndexOfValue(
+                String.format(Locale.US, "%.02f", currentValue));
+        if (index < 0) index = 0;
+        mListPreference.setValueIndex(index);
+        mListPreference.setSummary(mListPreference.getEntries()[index]);
     }
 
     @Override
-    public void onStop() {
-        mDeviceConfigDisplaySettings.stopListening();
+    public boolean onPreferenceChange(Preference preference, Object newValue) {
+        Settings.System.putFloat(mContext.getContentResolver(), PEAK_REFRESH_RATE,
+                Float.valueOf((String) newValue));
+        updateState(preference);
+        return true;
     }
 
-    private float findPeakRefreshRate(Display.Mode[] modes) {
-        float peakRefreshRate = DEFAULT_REFRESH_RATE;
-        for (Display.Mode mode : modes) {
-            if (Math.round(mode.getRefreshRate()) > DEFAULT_REFRESH_RATE) {
-                peakRefreshRate = mode.getRefreshRate();
-            }
-        }
-        return peakRefreshRate;
-    }
-
-    private class DeviceConfigDisplaySettings
-            implements DeviceConfig.OnPropertiesChangedListener, Executor {
-        public void startListening() {
-            DeviceConfig.addOnPropertiesChangedListener(
-                    DeviceConfig.NAMESPACE_DISPLAY_MANAGER,
-                    this /* Executor */,
-                    this /* Listener */);
-        }
-
-        public void stopListening() {
-            DeviceConfig.removeOnPropertiesChangedListener(this);
-        }
-
-        public float getDefaultPeakRefreshRate() {
-            float defaultPeakRefreshRate =
-                    DeviceConfig.getFloat(
-                            DeviceConfig.NAMESPACE_DISPLAY_MANAGER,
-                            DisplayManager.DeviceConfig.KEY_PEAK_REFRESH_RATE_DEFAULT,
-                            INVALIDATE_REFRESH_RATE);
-            Log.d(TAG, "DeviceConfig getDefaultPeakRefreshRate : " + defaultPeakRefreshRate);
-
-            return defaultPeakRefreshRate;
-        }
-
-        @Override
-        public void onPropertiesChanged(DeviceConfig.Properties properties) {
-            // Got notified if any property has been changed in NAMESPACE_DISPLAY_MANAGER. The
-            // KEY_PEAK_REFRESH_RATE_DEFAULT value could be added, changed, removed or unchanged.
-            // Just force a UI update for any case.
-            if (mOnDeviceConfigChange != null) {
-                mOnDeviceConfigChange.onDefaultRefreshRateChanged();
-                updateState(mPreference);
-            }
-        }
-
-        @Override
-        public void execute(Runnable runnable) {
-            if (mHandler != null) {
-                mHandler.post(runnable);
-            }
-        }
-    }
-
-    private float getDefaultPeakRefreshRate() {
-        float defaultPeakRefreshRate = mDeviceConfigDisplaySettings.getDefaultPeakRefreshRate();
-        if (defaultPeakRefreshRate == INVALIDATE_REFRESH_RATE) {
-            defaultPeakRefreshRate = (float) mContext.getResources().getInteger(
-                    com.android.internal.R.integer.config_defaultPeakRefreshRate);
-        }
-
-        return defaultPeakRefreshRate;
-    }
 }


### PR DESCRIPTION
This should be superior to AOSP's impl of smooth display as that limits you to only one Max Refresh rate, while this implementation should allow the maximum and minimum refresh rates to be selectable by the end user while still retaining AOSP's adaptive surfaceflinger-based refresh rate

Change-Id: I4765612c3e4cc63c1d4cdd04e28b6382fdf604cb